### PR TITLE
Removed GetTrigger

### DIFF
--- a/ontology/interop/System/Runtime.py
+++ b/ontology/interop/System/Runtime.py
@@ -1,12 +1,5 @@
 
 
-def GetTrigger():
-    """
-
-    """
-    pass
-
-
 def CheckWitness(hash_or_pubkey):
     """
 


### PR DESCRIPTION
There isn't a need to have `GetTrigger` in the python compiler. This is a leftover feature from the neo-boa compiler for NEO. The concept of triggers doesn't exist in Ontology.

Signed off by Wyatt Mufson <wyatt@ryucoin.com>