### PR TITLE
Ontology.code folder updated to PEP8 style

### DIFF
--- a/ontology/code/CodeGenerate_By_Ast.py
+++ b/ontology/code/CodeGenerate_By_Ast.py
@@ -12,50 +12,57 @@ from ontology import __version__
 from ontology.code.StaticAppCall import RegisterAppCall, NotifyAction
 
 # Global arg set.
-ONTOLOGY_SC_FRAMEWORK       = 'ontology.interop.'
-ONTOLOGY_SC_FRAMEWORK_boa   = 'boa.interop.'
-ONTOLOGY_BUILTINS_M         = 'ontology.builtins'
-ONTOLOGY_BUILTINS_M_boa     = 'boa.builtins'
-OwnMainModule               = 'OwnMainModule'
-ForIndexPrefix              = 'ForIndexPrefix_Var###'
-ListCompName                = 'ListCompName###'
-ref_type_local              = 'Local'
-ref_type_global             = 'Global'
-Builtins_Module             = 'ontology.builtins'
-Global_VarEnv               = 'Global_VarEnv###FixedName'
+ONTOLOGY_SC_FRAMEWORK = 'ontology.interop.'
+ONTOLOGY_SC_FRAMEWORK_boa = 'boa.interop.'
+ONTOLOGY_BUILTINS_M = 'ontology.builtins'
+ONTOLOGY_BUILTINS_M_boa = 'boa.builtins'
+OwnMainModule = 'OwnMainModule'
+ForIndexPrefix = 'ForIndexPrefix_Var###'
+ListCompName = 'ListCompName###'
+ref_type_local = 'Local'
+ref_type_global = 'Global'
+Builtins_Module = 'ontology.builtins'
+Global_VarEnv = 'Global_VarEnv###FixedName'
 Global_simulation_func_name = 'Global#Code'
-BUILTIN_AND_SYSCALL_LABEL_ADDR  = -2
+BUILTIN_AND_SYSCALL_LABEL_ADDR = -2
 # keys, values, has_key current not support
 # buildins_list           = ['state', 'bytes', 'bytearray', 'ToScriptHash', 'print', 'list', 'len', 'abs', 'min', 'max', 'concat', 'take', 'substr', 'keys', 'values', 'has_key', 'sha1', 'sha256', 'hash160', 'hash256', 'verify_signature', 'reverse', 'append', 'remove', 'Exception', 'throw_if_null', 'breakpoint']
-ONE_LINE_EXPR_SUPPORT_AST_TYPE   = ['Pass', 'Str']
+ONE_LINE_EXPR_SUPPORT_AST_TYPE = ['Pass', 'Str']
 # xxx. Migrate have return value acctually.
 WITHOUT_RETURN_BUILTINSYSCALL = ['print', 'Log', 'throw_if_null', 'breakpoint', 'Notify', 'Put', 'Destroy', 'Delete', 'Exception']
 # all these three List_Attr_func assumed no return value.
 List_Attr_func = ['append', 'remove', 'reverse']
 warning_file_path = None
 
+
 def print_location():
     f_frame = sys._getframe().f_back
-    print("Location: ",f_frame.f_code.co_filename, f_frame.f_lineno, f_frame.f_code.co_name)
+    print("Location: ", f_frame.f_code.co_filename, f_frame.f_lineno, f_frame.f_code.co_name)
+
 
 def Print_DoNot_Support(func_desc, node, message):
-    raise Exception("[Compiler ERROR. File: %s. in function: %s. Line: %d]. The Neptune Compiler does not support %s" %(func_desc.filepath, func_desc.name, node.lineno, message))
+    raise Exception("[Compiler ERROR. File: %s. in function: %s. Line: %d]. The Neptune Compiler does not support %s" % (func_desc.filepath, func_desc.name, node.lineno, message))
 
-def Print_Error(func_desc, node , message):
-    raise Exception("[Compiler ERROR. File: %s. in function: %s. Line: %d]. %s" %(func_desc.filepath, func_desc.name, node.lineno, message))
+
+def Print_Error(func_desc, node, message):
+    raise Exception("[Compiler ERROR. File: %s. in function: %s. Line: %d]. %s" % (func_desc.filepath, func_desc.name, node.lineno, message))
+
 
 def Print_Not_Support(filepath, node, message):
-    raise Exception("[Compiler ERROR. File: %s. Line: %d]. The Neptune Compiler does not support %s" %(filepath, node.lineno, message))
+    raise Exception("[Compiler ERROR. File: %s. Line: %d]. The Neptune Compiler does not support %s" % (filepath, node.lineno, message))
 
-def Print_Error_global(filepath, node , message):
-    raise Exception("[Compiler ERROR. File: %s. Line: %d]. %s" %(filepath, node.lineno, message))
+
+def Print_Error_global(filepath, node, message):
+    raise Exception("[Compiler ERROR. File: %s. Line: %d]. %s" % (filepath, node.lineno, message))
+
 
 def Print_Warning_global(filepath, node, message):
-    assert(warning_file_path != None)
-    message_w = "[Compiler WARNING. File: %s. Line: %d.] %s" %(filepath, node.lineno, message)
+    assert(warning_file_path is not None)
+    message_w = "[Compiler WARNING. File: %s. Line: %d.] %s" % (filepath, node.lineno, message)
     print(message_w)
     with open(warning_file_path, 'a+') as out_file:
         out_file.write(message_w)
+
 
 class Visit_FirstGlobalNode(ast.NodeVisitor):
     def __init__(self):
@@ -67,7 +74,7 @@ class Visit_FirstGlobalNode(ast.NodeVisitor):
     def visit_Module(self, node):
         for stmt in node.body:
             self.visit(stmt)
-            if self.first_global_node != None:
+            if self.first_global_node is not None:
                 break
 
     def visit_Import(self, node):
@@ -76,28 +83,30 @@ class Visit_FirstGlobalNode(ast.NodeVisitor):
     def visit_ImportFrom(self, node):
         pass
 
+
 class generic_modify_node(ast.NodeTransformer):
     def generic_visit(self, node):
         if hasattr(node, "lineno"):
             self.parent_node_lineno = node.lineno
-            self.parent_node_col    = node.col_offset
+            self.parent_node_col = node.col_offset
         ast.NodeVisitor.generic_visit(self, node)
         return node
 
     def visit_In(self, node):
-        node.lineno         = self.parent_node_lineno
-        node.col_offset     = self.parent_node_col
+        node.lineno = self.parent_node_lineno
+        node.col_offset = self.parent_node_col
         return node
 
     def visit_NotIn(self, node):
-        node.lineno         = self.parent_node_lineno
-        node.col_offset     = self.parent_node_col
+        node.lineno = self.parent_node_lineno
+        node.col_offset = self.parent_node_col
         return node
 
     def visit_arguments(self, node):
-        node.lineno         = self.parent_node_lineno
-        node.col_offset     = self.parent_node_col
+        node.lineno = self.parent_node_lineno
+        node.col_offset = self.parent_node_col
         return node
+
 
 class ReWrite_CTX_STORE_TO_LOAD(ast.NodeTransformer):
     def __init__(self, func_desc):
@@ -125,6 +134,7 @@ class ReWrite_CTX_STORE_TO_LOAD(ast.NodeTransformer):
         assert(type(node.ctx).__name__ == 'Store')
         Print_DoNot_Support(self.func_desc, node, "Attrubute Store type")
 
+
 class ReWrite_CTX_LOAD_TO_STORE(ast.NodeTransformer):
     def visit_Name(self, node):
         assert(type(node.ctx).__name__ == 'Load')
@@ -136,6 +146,7 @@ class ReWrite_CTX_LOAD_TO_STORE(ast.NodeTransformer):
         node.ctx = ast.Store()
         return node
 
+
 class CVersion_Visitor(ast.NodeVisitor):
     def __init__(self, codegencontext):
         self.OntCversion = None
@@ -143,35 +154,36 @@ class CVersion_Visitor(ast.NodeVisitor):
 
     def generic_visit(self, node):
         if hasattr(node, 'lineno') and node.lineno == 1:
-            if type(node).__name__ == 'Assign' and  len(node.targets) == 1 and type(node.targets[0]).__name__ == 'Name' and type(node.value).__name__ ==  'Str':
+            if type(node).__name__ == 'Assign' and len(node.targets) == 1 and type(node.targets[0]).__name__ == 'Name' and type(node.value).__name__ == 'Str':
                 self.OntCversion = node.value.s
                 if self.OntCversion != __version__ or node.targets[0].id != 'OntCversion':
-                    Print_Warning_global(self.codegencontext.main_file_path, node, "Place 'OntCversion = '%s'' at 1st line of SmartContract." %(__version__))
+                    Print_Warning_global(self.codegencontext.main_file_path, node, "Place 'OntCversion = '%s'' at 1st line of SmartContract." % (__version__))
             else:
-                Print_Warning_global(self.codegencontext.main_file_path, node, "Place 'OntCversion = '%s'' at 1st line of SmartContract" %(__version__))
+                Print_Warning_global(self.codegencontext.main_file_path, node, "Place 'OntCversion = '%s'' at 1st line of SmartContract" % (__version__))
             return
 
-        Print_Warning_global(self.codegencontext.main_file_path, node, "Place 'OntCversion = '%s'' at 1st line of SmartContract" %(__version__))
+        Print_Warning_global(self.codegencontext.main_file_path, node, "Place 'OntCversion = '%s'' at 1st line of SmartContract" % (__version__))
 
     def visit_Module(self, node):
         self.generic_visit(node.body[0])
 
+
 class FuncVisitor_Of_AnalyzeReturnValue(ast.NodeVisitor):
     def __init__(self, func_desc):
-        self.func_desc      = func_desc
-        self.current_node   = None
-        self.already_visited    = False
-        self.visit_returned       = False
+        self.func_desc = func_desc
+        self.current_node = None
+        self.already_visited = False
+        self.visit_returned = False
 
-    def Print_DoNot_Support(self, node ,message):
-        raise Exception("[Compiler ERROR. File: %s in function: %s Line: %d]. The Neptuen Compiler does not support %s" %(self.func_desc.filepath, self.func_desc.name, node.lineno, message))
+    def Print_DoNot_Support(self, node, message):
+        raise Exception("[Compiler ERROR. File: %s in function: %s Line: %d]. The Neptuen Compiler does not support %s" % (self.func_desc.filepath, self.func_desc.name, node.lineno, message))
 
     def Print_Error(self, node, message):
-        raise Exception("[Compiler ERROR. File: %s in function: %s Line: %d]. %s" %(self.func_desc.filepath, self.func_desc.name, node.lineno, message))
+        raise Exception("[Compiler ERROR. File: %s in function: %s Line: %d]. %s" % (self.func_desc.filepath, self.func_desc.name, node.lineno, message))
 
     def visit_FunctionDef(self, node):
         self.current_node = node
-        if self.already_visited :
+        if self.already_visited:
             self.Print_DoNot_Support(node, "function define in function.")
         self.already_visited = True
 
@@ -181,16 +193,17 @@ class FuncVisitor_Of_AnalyzeReturnValue(ast.NodeVisitor):
 
     def visit_Return(self, node):
         self.current_node = node
-        if self.func_desc.have_return_value and node.value == None:
-            self.Print_Error(node, "You are returning a value and None, this will result in an error." )
-
-        if self.visit_returned and (not self.func_desc.have_return_value) and node.value != None:
+        if self.func_desc.have_return_value and node.value is None:
             self.Print_Error(node, "You are returning a value and None, this will result in an error.")
 
-        if node.value != None :
+        if self.visit_returned and (not self.func_desc.have_return_value) and node.value is not None:
+            self.Print_Error(node, "You are returning a value and None, this will result in an error.")
+
+        if node.value is not None:
             self.func_desc.have_return_value = True
 
         self.visit_returned = True
+
 
 class Abivisitor_step0(ast.NodeVisitor):
     def __init__(self):
@@ -205,8 +218,9 @@ class Abivisitor_step0(ast.NodeVisitor):
         self.checking_abilist = False
 
     def visit_Compare(self, node):
-        if self.checking_abilist == True and type(node.left).__name__ == 'Name' and node.left.id == 'operation' and len(node.ops) == 1 and type(node.ops[0]).__name__ == 'Eq' and len(node.comparators) == 1 and type(node.comparators[0]).__name__ == 'Str':
+        if self.checking_abilist and type(node.left).__name__ == 'Name' and node.left.id == 'operation' and len(node.ops) == 1 and type(node.ops[0]).__name__ == 'Eq' and len(node.comparators) == 1 and type(node.comparators[0]).__name__ == 'Str':
             self.Funclist.append(node.comparators[0].s)
+
 
 class Abivisitor_step1(ast.NodeVisitor):
     def __init__(self, funclist):
@@ -214,22 +228,23 @@ class Abivisitor_step1(ast.NodeVisitor):
         self.AbiFunclist = []
 
     def visit_FunctionDef(self, node):
-        args =[]
+        args = []
         if node.name in self.Funclist:
             # contruct args list first
             for arg in node.args.args:
-                args.append({"name": arg.arg, "type":""})
+                args.append({"name": arg.arg, "type": ""})
 
-            self.AbiFunclist.append({"name":node.name, "parameters":args})
+            self.AbiFunclist.append({"name": node.name, "parameters": args})
+
 
 class FuncVisitor_Of_StackSize(ast.NodeVisitor):
     def __init__(self, func_desc, is_global):
-        self.stack_size         = 0
-        self.func_desc          = func_desc
-        self.already_visited    = False
-        self.current_node       = None
-        self.arg_num            = 0
-        self.is_global          = is_global
+        self.stack_size = 0
+        self.func_desc = func_desc
+        self.already_visited = False
+        self.current_node = None
+        self.arg_num = 0
+        self.is_global = is_global
 
     def generic_visit(self, node):
         self.current_node = node
@@ -237,12 +252,12 @@ class FuncVisitor_Of_StackSize(ast.NodeVisitor):
 
     def Print_DoNot_Support(self, node, message):
         if hasattr(node, 'lineno'):
-            raise Exception("[Compiler ERROR. File: %s. in function: %s. Line: %d]. The Neptune Compiler does not support %s" %(self.func_desc.filepath, self.func_desc.name, node.lineno, message))
+            raise Exception("[Compiler ERROR. File: %s. in function: %s. Line: %d]. The Neptune Compiler does not support %s" % (self.func_desc.filepath, self.func_desc.name, node.lineno, message))
         else:
-            raise Exception("[Compiler ERROR. File: %s. in function: %s. ]. The Neptune Compiler does not support %s" %(self.func_desc.filepath, self.func_desc.name, message))
+            raise Exception("[Compiler ERROR. File: %s. in function: %s. ]. The Neptune Compiler does not support %s" % (self.func_desc.filepath, self.func_desc.name, message))
 
     def Print_Error(self, node, message):
-        raise Exception("[Compiler ERROR. File: %s. in function: %s. Line: %d]. %s" %(self.func_desc.filepath, self.func_desc.name, node.lineno, message))
+        raise Exception("[Compiler ERROR. File: %s. in function: %s. Line: %d]. %s" % (self.func_desc.filepath, self.func_desc.name, node.lineno, message))
 
     def visit_FunctionDef(self, node):
         if self.is_global:
@@ -277,14 +292,14 @@ class FuncVisitor_Of_StackSize(ast.NodeVisitor):
         if (self.func_desc.isyscall or self.func_desc.is_builtin) and (self.func_desc.name == "RegisterAppCall" or self.func_desc.name == "DynamicAppCall" or self.func_desc.name == "RegisterAction" or self.func_desc.name == 'state'):
             pass
         else:
-            if node.vararg != None:
+            if node.vararg is not None:
                 self.Print_DoNot_Support(node, "vararg.")
 
             if node.defaults != []:
                 self.Print_DoNot_Support(node, "defaults.")
 
-        self.func_desc.arg_num    = len(node.args)
-        self.arg_num    = len(node.args)
+        self.func_desc.arg_num = len(node.args)
+        self.arg_num = len(node.args)
         self.stack_size += len(node.args)
 
     def visit_Return(self, node):
@@ -296,7 +311,7 @@ class FuncVisitor_Of_StackSize(ast.NodeVisitor):
 
     def visit_For(self, node):
         self.current_node = node
-        # index, result, iter , len
+        # index, result, iter, len
         self.stack_size += 4
         self.generic_visit(node)
 
@@ -312,12 +327,13 @@ class FuncVisitor_Of_StackSize(ast.NodeVisitor):
         self.stack_size += 1
         self.generic_visit(node)
 
+
 class Visitor_Of_Global(ast.NodeVisitor):
     def __init__(self, codegencontext):
         self.global_num = 0
         self.codegencontext = codegencontext
 
-    def visit_Return(self,node):
+    def visit_Return(self, node):
         Print_Error_global(self.codegencontext.main_file_path, node, "can not \"return\" outside of function.")
 
     def generic_visit(self, node):
@@ -340,7 +356,7 @@ class Visitor_Of_Global(ast.NodeVisitor):
                 new_app_call = RegisterAppCall(register_func_name, args)
                 assert(newfunc.arg_num >= 0)
                 if register_func_name in self.codegencontext.register_appcall.keys():
-                    Print_Error_global(self.codegencontext.main_file_path, node, "%s registered before." %(register_func_name))
+                    Print_Error_global(self.codegencontext.main_file_path, node, "%s registered before." % (register_func_name))
                 self.codegencontext.register_appcall[register_func_name] = new_app_call
                 return
             elif self.codegencontext.funcscope[node.value.func.id].isyscall and node.value.func.id == 'RegisterAction':
@@ -355,7 +371,7 @@ class Visitor_Of_Global(ast.NodeVisitor):
                 assert(newfunc.arg_num >= 0)
                 newaction = NotifyAction(register_func_name, args)
                 if register_func_name in self.codegencontext.register_action.keys():
-                    Print_Error_global(self.codegencontext.main_file_path, node, "%s registered before." %(register_func_name))
+                    Print_Error_global(self.codegencontext.main_file_path, node, "%s registered before." % (register_func_name))
                 self.codegencontext.register_action[register_func_name] = newaction
                 return
             else:
@@ -364,48 +380,49 @@ class Visitor_Of_Global(ast.NodeVisitor):
         self.global_num += len(node.targets)
         self.generic_visit(node)
 
+
 class Visitor_Of_FuncDecl(ast.NodeVisitor):
     def __init__(self, codegencontext, visited_module, list_func_imported):
-        self.main_func_node     = None
-        self.visited_module     = visited_module;
-        self.codegencontext     = codegencontext
-        self.isyscall_module    = False
-        self.is_builtin_module  = False
-        self.is_main_module     = False
+        self.main_func_node = None
+        self.visited_module = visited_module
+        self.codegencontext = codegencontext
+        self.isyscall_module = False
+        self.is_builtin_module = False
+        self.is_main_module = False
         self.list_func_imported = list_func_imported
         if visited_module == OwnMainModule:
             self.is_main_module = True
-            assert(self.list_func_imported == None)
+            assert(self.list_func_imported is None)
 
         if visited_module != OwnMainModule:
             pymodule = importlib.import_module(visited_module, visited_module)
             module_file_path = pymodule.__file__
             source = open(module_file_path, 'rb')
             source_src = source.read()
-            self.module_file_path   = module_file_path
-            self.module_ast_tree    = ast.parse(source_src)
+            self.module_file_path = module_file_path
+            self.module_ast_tree = ast.parse(source_src)
         else:
-            self.module_file_path   = self.codegencontext.main_file_path
-            self.module_ast_tree    = self.codegencontext.main_astree
+            self.module_file_path = self.codegencontext.main_file_path
+            self.module_ast_tree = self.codegencontext.main_astree
 
         if (ONTOLOGY_SC_FRAMEWORK in self.visited_module) or (ONTOLOGY_SC_FRAMEWORK_boa in self.visited_module):
             self.isyscall_module = True
         elif (self.visited_module == ONTOLOGY_BUILTINS_M) or (self.visited_module == ONTOLOGY_BUILTINS_M_boa):
             self.is_builtin_module = True
 
-        assert((self.isyscall_module and self.is_builtin_module) == False)
+        assert(not (self.isyscall_module and self.is_builtin_module))
 
     # here do not need visit the children node. so do not call the generic_visit.
     def visit_FunctionDef(self, node):
         if node.name == 'main' or node.name == 'Main':
             if not self.is_main_module:
-                Print_Error_global(self.module_file_path , node, "%s was Imported. Can not have Main func other the main file of your project." %(self.visited_module))
+                Print_Error_global(self.module_file_path, node, "%s was Imported. Can not have Main func other the main file of your project." % (self.visited_module))
 
             self.main_func_node = node
             return
 
         if self.is_main_module:
-            assert(self.list_func_imported == None)
+            assert(self.list_func_imported is None)
             self.codegencontext.NewFunc(node, self.isyscall_module, self.module_file_path, self.visited_module, False)
         else:
             assert(self.list_func_imported != [])
@@ -433,24 +450,25 @@ class Visitor_Of_FuncDecl(ast.NodeVisitor):
             if alias.name == 'range' and (node.module == ONTOLOGY_BUILTINS_M or node.module == ONTOLOGY_BUILTINS_M_boa):
                 # range depend on list
                 list_func_imported.append('list')
-            if alias.asname != None:
+            if alias.asname is not None:
                 Print_Not_Support(self.module_file_path,  node,  "from ... import .. as ..")
 
         self.codegencontext.ResolveFuncDecl(node.module, list_func_imported)
 
+
 class Visitor_Of_FunCodeGen(ast.NodeVisitor):
-    def __init__(self, codegencontext ,func_desc, is_for_global = False):
-        self.codegencontext     = codegencontext
-        self.func_desc          = func_desc
-        self.already_visited    = False
-        self.is_for_global      = is_for_global
-        self.current_node       = None
-        self.latest_loop_break_label    = []
-        self.is_in_loop         = False
+    def __init__(self, codegencontext, func_desc, is_for_global=False):
+        self.codegencontext = codegencontext
+        self.func_desc = func_desc
+        self.already_visited = False
+        self.is_for_global = is_for_global
+        self.current_node = None
+        self.latest_loop_break_label = []
+        self.is_in_loop = False
         self.codegencontext.tokenizer.current_func = func_desc
         self.codegencontext.tokenizer.global_converting = is_for_global
-        self.main_func_node     = None
-        self.global_declare     = []
+        self.main_func_node = None
+        self.global_declare = []
 
     def Get_FuncDesc(self, funcname, node):
         return self.codegencontext.Get_FuncDesc(funcname, node, self.func_desc.filepath)
@@ -458,18 +476,18 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
     # so when get a bug need check in this func. is there any node should transfered do not transfer.
     def generic_visit(self, node):
         self.current_node = node
-        #ast.NodeVisitor.generic_visit(self, node)
+        # ast.NodeVisitor.generic_visit(self, node)
         ast.NodeVisitor.generic_visit(self, node)
 
     def visit_ClassDef(self, node):
         self.current_node = node
         self.Print_DoNot_Support(node, "Class def.")
 
-    def Print_DoNot_Support(self, node ,message):
-        raise Exception("[Compiler ERROR. File: %s. in function: %s. Line: %d]. The Neptune Compiler does not support %s" %(self.func_desc.filepath, self.func_desc.name, node.lineno, message))
+    def Print_DoNot_Support(self, node, message):
+        raise Exception("[Compiler ERROR. File: %s. in function: %s. Line: %d]. The Neptune Compiler does not support %s" % (self.func_desc.filepath, self.func_desc.name, node.lineno, message))
 
     def Print_Error(self, node, message):
-        raise Exception("[Compiler ERROR. File: %s. in function: %s. Line: %d]. %s" %(self.func_desc.filepath, self.func_desc.name, node.lineno, message))
+        raise Exception("[Compiler ERROR. File: %s. in function: %s. Line: %d]. %s" % (self.func_desc.filepath, self.func_desc.name, node.lineno, message))
 
     def visit_Module(self, node):
         self.current_node = node
@@ -501,7 +519,7 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
                 self.codegencontext.SetLabel(self.codegencontext.funcscope[node.name].label, self.codegencontext.pc + 1)
 
             self.codegencontext.tokenizer.build_function_stack(self.func_desc.stack_size, self.func_desc.func_ast)
-            #ast.fix_missing_locations(node)
+            # ast.fix_missing_locations(node)
             self.generic_visit(node)
 
             if type(node.body[-1]).__name__ != 'Return':
@@ -518,7 +536,7 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
             self.Print_Error(node, "Compiler Bug. Global can not have argument.")
             assert(False)
 
-        if node.vararg != None:
+        if node.vararg is not None:
             self.Print_DoNot_Support(node, "vararg.")
 
         if node.defaults != []:
@@ -527,7 +545,7 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
         if self.func_desc.isyscall or self.func_desc.is_builtin:
             self.Print_Error(node, "Compiler Bug. builtins or syscall should not handle arguments. ")
 
-        GlobalArgNode = ast.Name(id = Global_VarEnv, ctx = ast.Load())
+        GlobalArgNode = ast.Name(id=Global_VarEnv, ctx=ast.Load())
         ast.copy_location(GlobalArgNode, node)
 
         position = self.func_desc.NewLocal(Global_VarEnv, GlobalArgNode)
@@ -537,8 +555,8 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
             position = self.func_desc.NewLocal(arg.arg, arg)
             self.codegencontext.tokenizer.Emit_StoreLocal(position, arg)
 
-        #self.Convert_Global()
-        #self.codegencontext.tokenizer.global_converting = False
+        # self.Convert_Global()
+        # self.codegencontext.tokenizer.global_converting = False
 
     def Convert_Global(self):
         if self.func_desc.blong_module_name != OwnMainModule:
@@ -593,14 +611,14 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
         if type(node.target).__name__ != 'Name':
             self.Print_DoNot_Support(node, "multi iter.")
 
-        #if node.orelse != []:
+        # if node.orelse != []:
         #    self.Print_DoNot_Support(node, "for orelse.")
 
-        #self.is_in_loop = True
+        # self.is_in_loop = True
         # alloc Label.
-        for_start_label         = self.codegencontext.NewLabel()
-        for_end_label           = self.codegencontext.NewLabel()
-        for_no_break_end_label  = self.codegencontext.NewLabel()
+        for_start_label = self.codegencontext.NewLabel()
+        for_end_label = self.codegencontext.NewLabel()
+        for_no_break_end_label = self.codegencontext.NewLabel()
 
         self.latest_loop_break_label = [for_start_label, for_end_label]
         # index_position: init index.
@@ -640,7 +658,7 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
         self.codegencontext.tokenizer.Emit_LoadLocal(result_position, node)
         self.codegencontext.tokenizer.Emit_LoadLocal(index_position, node)
         self.codegencontext.tokenizer.Emit_Token(VMOp.PICKITEM, node)
-        #target_position = self.func_desc.Get_LocalStackPosition(ForIndexPrefix + str(self.func_desc.for_position))
+        # target_position = self.func_desc.Get_LocalStackPosition(ForIndexPrefix + str(self.func_desc.for_position))
         assert(type(node.target).__name__ == 'Name')
         # acctually here can visit node.target.
         assert(type(node.target.ctx).__name__ == 'Store')
@@ -677,19 +695,19 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
             self.visit(stmt)
 
         self.codegencontext.SetLabel(for_end_label, self.codegencontext.pc + 1)
-        #self.codegencontext.tokenizer.Emit_Token(VMOp.NOP, stmt)
+        # self.codegencontext.tokenizer.Emit_Token(VMOp.NOP, stmt)
 
     def visit_While(self, node):
         self.current_node = node
 
-        #if node.orelse !=[]:
+        # if node.orelse !=[]:
         #    self.Print_DoNot_Support(node, "While orelse.")
 
         # alloc Label.
         self.is_in_loop = True
         while_start_label = self.codegencontext.NewLabel()
-        while_end_label   = self.codegencontext.NewLabel()
-        while_no_break_end_label  = self.codegencontext.NewLabel()
+        while_end_label = self.codegencontext.NewLabel()
+        while_no_break_end_label = self.codegencontext.NewLabel()
 
         self.latest_loop_break_label = [while_start_label, while_end_label]
         jumpostion_while_start = while_start_label.to_bytes(2, 'little', signed=True)
@@ -730,8 +748,8 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
             self.Print_Error(node, "You cannot break outside of a loop.")
         assert(len(self.latest_loop_break_label) == 2)
         # jmp to the end label
-        target_label    = self.latest_loop_break_label[1]
-        target_postion  = target_label.to_bytes(2, 'little', signed=True)
+        target_label = self.latest_loop_break_label[1]
+        target_postion = target_label.to_bytes(2, 'little', signed=True)
         self.codegencontext.tokenizer.Emit_Token(VMOp.JMP, node, target_postion)
 
     def visit_Continue(self, node):
@@ -740,8 +758,8 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
             self.Print_Error(node, "You cannot continue outside of a loop.")
         assert(len(self.latest_loop_break_label) == 2)
         # jmp to the end label
-        target_label    = self.latest_loop_break_label[0]
-        target_postion  = target_label.to_bytes(2, 'little', signed=True)
+        target_label = self.latest_loop_break_label[0]
+        target_postion = target_label.to_bytes(2, 'little', signed=True)
         self.codegencontext.tokenizer.Emit_Token(VMOp.JMP, node, target_postion)
 
     def visit_If(self, node):
@@ -777,35 +795,45 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
 
     def visit_Add(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.ADD, node)
+
     def visit_Sub(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.SUB, node)
+
     def visit_Mult(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.MUL, node)
+
     def visit_Div(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.DIV, node)
+
     def visit_Mod(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.MOD, node)
+
     def visit_LShift(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.SHL, node)
+
     def visit_RShift(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.SHR, node)
+
     def visit_BitOr(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.OR, node)
+
     def visit_BitXor(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.XOR, node)
+
     def visit_BitAnd(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.AND, node)
+
     def visit_FloorDiv(self, node):
-        raise Exception("[Compiler ERROR. File: %s. in function: %s.]. The Neptune Compiler does not support %s" %(self.func_desc.filepath, self.func_desc.name, "FloorDiv"))
+        raise Exception("[Compiler ERROR. File: %s. in function: %s.]. The Neptune Compiler does not support %s" % (self.func_desc.filepath, self.func_desc.name, "FloorDiv"))
 
     def visit_BoolOp(self, node):
         assert(len(node.values) >= 2)
-        End_target_label        = self.codegencontext.NewLabel()
-        End_target_postion      = End_target_label.to_bytes(2, 'little', signed=True)
+        End_target_label = self.codegencontext.NewLabel()
+        End_target_postion = End_target_label.to_bytes(2, 'little', signed=True)
 
         for i in range(len(node.values)):
             self.visit(node.values[i])
-            if  i != (len(node.values) - 1):
+            if i != (len(node.values) - 1):
                 if (type(node.op).__name__ == 'Or'):
                     self.codegencontext.tokenizer.Emit_Token(VMOp.DUP, node)
                     self.codegencontext.tokenizer.Emit_Token(VMOp.JMPIF, node, End_target_postion)
@@ -821,23 +849,31 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
 
     def visit_And(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.BOOLAND, node)
+
     def visit_Or(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.BOOLOR, node)
 
     def visit_Eq(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.NUMEQUAL, node)
+
     def visit_NotEq(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.NUMNOTEQUAL, node)
+
     def visit_Lt(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.LT, node)
+
     def visit_LtE(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.LTE, node)
+
     def visit_Gt(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.GT, node)
+
     def visit_GtE(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.GTE, node)
+
     def visit_Is(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.EQUAL, node)
+
     def visit_IsNot(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.EQUAL, node)
         self.codegencontext.tokenizer.Emit_Token(VMOp.NOT, node)
@@ -845,13 +881,13 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
     def visit_In(self, node):
 
         # assume target a, and iter l in stack like the first below.
-        Start_target_label          = self.codegencontext.NewLabel()
-        End_target_label            = self.codegencontext.NewLabel()
-        End_target_label_bytes      = End_target_label.to_bytes(2, 'little', signed=True)
-        Start_target_label_bytes    = Start_target_label.to_bytes(2, 'little', signed=True)
+        Start_target_label = self.codegencontext.NewLabel()
+        End_target_label = self.codegencontext.NewLabel()
+        End_target_label_bytes = End_target_label.to_bytes(2, 'little', signed=True)
+        Start_target_label_bytes = Start_target_label.to_bytes(2, 'little', signed=True)
 
         # a, l
-        self.codegencontext.tokenizer.Emit_Token(VMOp.PUSH0, node) # set i to 0
+        self.codegencontext.tokenizer.Emit_Token(VMOp.PUSH0, node)  # set i to 0
         self.codegencontext.SetLabel(Start_target_label, self.codegencontext.pc + 1)
 
         # a, l, i. while start.
@@ -938,17 +974,20 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
 
     def visit_Not(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.NOT, node)
+
     def visit_Invert(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.INVERT, node)
+
     def visit_UnaryOp(self, node):
         self.current_node = node
         if type(node.op).__name__ in ['USub', 'UAdd']:
-            self.codegencontext.tokenizer.Emit_Integer(0 , node)
+            self.codegencontext.tokenizer.Emit_Integer(0, node)
         self.visit(node.operand)
         self.visit(node.op)
 
     def visit_UAdd(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.ADD, node)
+
     def visit_USub(self, node):
         self.codegencontext.tokenizer.Emit_Token(VMOp.SUB, node)
 
@@ -968,7 +1007,7 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
 
     def visit_Assert(self, node):
         self.current_node = node
-        if node.msg != None:
+        if node.msg is not None:
             self.Print_DoNot_Support(node, "Assert with message.")
         self.visit(node.test)
         self.codegencontext.tokenizer.Emit_Token(VMOp.THROWIFNOT, node)
@@ -982,7 +1021,7 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
                 self.visit(expr)
 
             self.codegencontext.tokenizer.Emit_Integer(len(node.elts), node)
-            self.codegencontext.tokenizer.Emit_Token(VMOp.PACK , node)
+            self.codegencontext.tokenizer.Emit_Token(VMOp.PACK, node)
             self.codegencontext.tokenizer.Emit_Token(VMOp.DUP, node)
             self.codegencontext.tokenizer.Emit_Token(VMOp.REVERSE, node)
 
@@ -997,15 +1036,15 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
         assert(func_desc.isyscall or func_desc.is_builtin)
         self.visit(attr.value)
 
-        if  func_desc.arg_num != len(node.args):
-            self.Print_Error(node, "Function '%s' requires exactly '%d' arguments but you passed '%d' args" %(func_name, func_desc.arg_num,len(node.args)))
+        if func_desc.arg_num != len(node.args):
+            self.Print_Error(node, "Function '%s' requires exactly '%d' arguments but you passed '%d' args" % (func_name, func_desc.arg_num, len(node.args)))
 
         for arg in reversed(node.args):
             self.visit(arg)
 
         vmtoken = self.codegencontext.tokenizer.Emit_Builtins(func_name, node)
-        if vmtoken == None:
-            self.Print_DoNot_Support(node, "builtin '%s'." %(funcname))
+        if vmtoken is None:
+            self.Print_DoNot_Support(node, "builtin '%s'." % (func_name))
 
     def visit_Call(self, node):
         self.current_node = node
@@ -1023,7 +1062,7 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
         func_desc = self.Get_FuncDesc(funcname, node)
 
         if funcname in List_Attr_func:
-            self.Print_Error(node, "function '%s' is list attribute call, you cannot call it directly." %(funcname))
+            self.Print_Error(node, "function '%s' is list attribute call, you cannot call it directly." % (funcname))
 
         # prepare args. note. concat, take, has_key, substr do not need reverse
         if funcname in ['concat', 'take', 'has_key', 'substr']:
@@ -1031,15 +1070,15 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
                 self.visit(arg)
         else:
             # RegisterAppCall and RegisterAction is handle by visitor of global
-            if  func_desc.isyscall and (func_desc.name == "RegisterAppCall" or func_desc.name == "RegisterAction"):
+            if func_desc.isyscall and (func_desc.name == "RegisterAppCall" or func_desc.name == "RegisterAction"):
                 return
 
             # DynamicAppCall get the vararg args.
-            if  (func_desc.isyscall or func_desc.is_builtin) and (func_desc.name == "DynamicAppCall" or func_desc.name == 'state'):
+            if (func_desc.isyscall or func_desc.is_builtin) and (func_desc.name == "DynamicAppCall" or func_desc.name == 'state'):
                 pass
             else:
-                if  func_desc.arg_num != len(node.args):
-                    self.Print_Error(node, "Function '%s' requires exactly '%d' arguments but you passed '%d' args" %(funcname, func_desc.arg_num,len(node.args)))
+                if func_desc.arg_num != len(node.args):
+                    self.Print_Error(node, "Function '%s' requires exactly '%d' arguments but you passed '%d' args" % (funcname, func_desc.arg_num, len(node.args)))
             for arg in reversed(node.args):
                 self.visit(arg)
 
@@ -1058,8 +1097,8 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
                 self.codegencontext.tokenizer.Emit_Token(VMOp.FROMALTSTACK, node)
                 return
             vmtoken = self.codegencontext.tokenizer.Emit_Builtins(funcname, node)
-            if vmtoken == None:
-                self.Print_DoNot_Support(node, "builtin '%s'." %(funcname))
+            if vmtoken is None:
+                self.Print_DoNot_Support(node, "builtin '%s'." % (funcname))
             return
         else:
             assert(func_desc.isyscall)
@@ -1083,10 +1122,10 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
                 action_reset_the_syscall_name = True
 
             if action_reset_the_syscall_name:
-                sys_name =  'System.Runtime.Notify'
+                sys_name = 'System.Runtime.Notify'
                 syscall_name = sys_name.encode('utf-8')
             else:
-                sys_name =  func_desc.blong_module_name +'.' + func_desc.name
+                sys_name = func_desc.blong_module_name + '.' + func_desc.name
                 if 'System.Header.GetBlockHash' in sys_name:
                     sys_name = sys_name.replace('GetBlockHash', 'GetHash')
                 elif 'System.Transaction.GetTransactionHash' in sys_name:
@@ -1103,9 +1142,9 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
             systemcall_name_array = bytearray([length]) + bytearray(syscall_name)
             vmtoken = self.codegencontext.tokenizer.Emit_Token(VMOp.SYSCALL, node, systemcall_name_array)
 
-            syscall_print           = sys_name.replace(ONTOLOGY_SC_FRAMEWORK, '')
-            syscall_print           = syscall_print.replace(ONTOLOGY_SC_FRAMEWORK_boa, '')
-            vmtoken.syscall_name    = syscall_print
+            syscall_print = sys_name.replace(ONTOLOGY_SC_FRAMEWORK, '')
+            syscall_print = syscall_print.replace(ONTOLOGY_SC_FRAMEWORK_boa, '')
+            vmtoken.syscall_name = syscall_print
 
             return
 
@@ -1120,8 +1159,8 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
     # only save a bool(true or false) to the evalution stack.
     def visit_Compare(self, node):
         self.current_node = node
-        opslen          = len(node.ops)
-        comparatorslen  = len(node.comparators)
+        opslen = len(node.ops)
+        comparatorslen = len(node.comparators)
         assert(opslen == comparatorslen)
         assert(opslen > 0)
 
@@ -1132,45 +1171,45 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
         self.visit(node.left)
 
         for i in range(opslen):
-            #V(n-1)
+            # V(n-1)
             self.visit(node.comparators[i])
 
-            #V(n-1), Vn
+            # V(n-1), Vn
 
             self.codegencontext.tokenizer.Emit_Token(VMOp.TUCK, node)
 
-            #V(n), V(n-1), V(n)
+            # V(n), V(n-1), V(n)
 
             self.visit(node.ops[i])
 
-            #V(n), B
+            # V(n), B
 
             if i == opslen - 1:
                 break
 
             self.codegencontext.tokenizer.Emit_Token(VMOp.DUP, node)
 
-            #V(n), B, B
+            # (n), B, B
 
             self.codegencontext.tokenizer.Emit_Token(VMOp.JMPIFNOT, node, jump_target_position)
 
-            #V(n), B
+            # V(n), B
 
             self.codegencontext.tokenizer.Emit_Token(VMOp.DROP, node)
 
-            #V(n)
+            # V(n)
 
         self.codegencontext.SetLabel(jump_target_label, self.codegencontext.pc + 1)
 
-        #V(n), B
+        # V(n), B
 
         self.codegencontext.tokenizer.Emit_Token(VMOp.SWAP, node)
 
-        #B, V(n)
+        # B, V(n)
 
         self.codegencontext.tokenizer.Emit_Token(VMOp.DROP, node)
 
-        #B. last return
+        # B. last return
 
     def visit_Num(self, node):
         self.current_node = node
@@ -1190,7 +1229,7 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
         global_postion = self.func_desc.Read_LocalStackPosition(Global_VarEnv, node)
 
         if not self.is_for_global:
-            assert(global_postion != None)
+            assert(global_postion is not None)
         self.current_node = node
 
         # like the orignal python sematic.
@@ -1199,16 +1238,16 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
 
             if self.check_var_global(node.id):
                 name_position = self.func_desc.Read_Global_Position(node.id)
-                if name_position == None:
+                if name_position is None:
                     Print_Error_global(self.func_desc.filepath, node, "Global Variable '%s' used before defined." % (node.id))
                 else:
                     self.codegencontext.tokenizer.Emit_LoadGlobal(name_position, global_postion, node)
             else:
                 name_position = self.func_desc.Read_LocalStackPosition(node.id, node)
-                if name_position == None:
+                if name_position is None:
                     name_position = self.func_desc.Read_Global_Position(node.id)
 
-                    if name_position == None:
+                    if name_position is None:
                         Print_Error_global(self.func_desc.filepath, node, "Variable '%s' used before defined." % (node.id))
 
                     self.codegencontext.tokenizer.Emit_LoadGlobal(name_position, global_postion, node)
@@ -1219,13 +1258,13 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
 
             if self.check_var_global(node.id):
                 name_position = self.func_desc.Read_Global_Position(node.id, node)
-                if name_position == None:
+                if name_position is None:
                     Print_Error_global(self.func_desc.filepath, node, "Global Variable '%s' used before defined." % (node.id))
                 else:
                     self.codegencontext.tokenizer.Emit_StoreGlobal(name_position, global_postion, node)
             else:
                 name_position = self.func_desc.Get_LocalStackPosition(node.id, node)
-                assert(name_position != None)
+                assert(name_position is not None)
                 self.codegencontext.tokenizer.Emit_StoreLocal(name_position, node)
                 assert(self.func_desc.ref_type[node.id] == ref_type_local)
 
@@ -1236,22 +1275,22 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
         """
         if type(node.ctx).__name__ == 'Load':
             name_position = self.func_desc.Read_LocalStackPosition(node.id, node)
-            if name_position != None:
+            if name_position is not None:
                 self.codegencontext.tokenizer.Emit_LoadLocal(name_position, node)
             else:
                 name_position = self.func_desc.Read_Global_Position(node.id)
-                if name_position == None:
+                if name_position is None:
                     Print_Error_global(self.func_desc.filepath, node, "Variable '%s' used before defined." % (node.id))
 
                 self.codegencontext.tokenizer.Emit_LoadGlobal(name_position, global_postion, node)
 
         elif type(node.ctx).__name__ == 'Store':
             name_position = self.func_desc.Read_LocalStackPosition(node.id, node)
-            if name_position != None:
+            if name_position is not None:
                 self.codegencontext.tokenizer.Emit_StoreLocal(name_position, node)
             else:
                 name_position = self.func_desc.Read_Global_Position(node.id)
-                if name_position == None:
+                if name_position is None:
                     name_position = self.func_desc.NewLocal(node.id, node)
                     self.codegencontext.tokenizer.Emit_StoreLocal(name_position, node)
                 else:
@@ -1269,10 +1308,10 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
                 self.codegencontext.tokenizer.Emit_Token(VMOp.PICKITEM, node)
             # note. here due to support str slice. how ever python can not difference the list and str by the node.value. so only can support one type slice.
             elif type(node.slice).__name__ == 'Slice':
-                if node.slice.step != None:
+                if node.slice.step is not None:
                     self.Print_DoNot_Support(node, "slice with step.")
 
-                if node.slice.upper != None:
+                if node.slice.upper is not None:
                     self.visit(node.slice.upper)
                     uppernode = node.slice.upper
                     if type(uppernode).__name__ == 'UnaryOp' and type(uppernode.op).__name__ == 'USub' and type(uppernode.operand).__name__ == 'Num':
@@ -1281,11 +1320,11 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
                     self.codegencontext.tokenizer.Emit_Token(VMOp.DUP, node)
                     self.codegencontext.tokenizer.Emit_Token(VMOp.ARRAYSIZE, node)
 
-                if node.slice.lower != None:
+                if node.slice.lower is not None:
                     self.visit(node.slice.lower)
                     lowernode = node.slice.lower
                     if type(lowernode).__name__ == 'UnaryOp' and type(lowernode.op).__name__ == 'USub' and type(lowernode.operand).__name__ == 'Num':
-                        self.Print_Error(node ,"slice lower smaller than 0.")
+                        self.Print_Error(node, "slice lower smaller than 0.")
                 else:
                     self.codegencontext.tokenizer.Emit_Integer(0, node)
 
@@ -1309,7 +1348,7 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
 
     def visit_Return(self, node):
         self.current_node = node
-        if node.value != None:
+        if node.value is not None:
             self.visit(node.value)
 
         self.codegencontext.tokenizer.Emit_Token(VMOp.FROMALTSTACK, node)
@@ -1322,7 +1361,7 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
             self.codegencontext.tokenizer.Emit_Integer(1, node)
         elif node.value == False:
             self.codegencontext.tokenizer.Emit_Integer(0, node)
-        elif node.value == None:
+        elif node.value is None:
             str_bytes = 'N'.encode('utf-8')
             self.codegencontext.tokenizer.Emit_Data(str_bytes, node)
             self.codegencontext.tokenizer.Emit_Integer(0, node)
@@ -1348,7 +1387,7 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
                         self.codegencontext.tokenizer.Emit_Token(VMOp.DROP, node)
                 # here hypothesis all buildins and syscall other than conditon will return a value.
                 elif not (funcname in WITHOUT_RETURN_BUILTINSYSCALL or funcname in self.codegencontext.register_action.keys()):
-                    self.Print_DoNot_Support(node, "Builtins or syscall %s call with no value assigned" %(funcname))
+                    self.Print_DoNot_Support(node, "Builtins or syscall %s call with no value assigned" % (funcname))
             elif type(node.value.func).__name__ == 'Attribute':
                 attr = node.value.func
                 assert(type(attr).__name__ == 'Attribute')
@@ -1420,7 +1459,7 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
                 bodyiftest.values       = []
                 for test in generator.ifs:
                     bodyiftest.values.append(test)
-                if node_for_prev == None:
+                if node_for_prev is None:
                     #bodyif.body         = [array_load, node_call]
                     bodyif.body         = [node_call]
                 else:
@@ -1434,13 +1473,13 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
                 bodyif.orelse           = []
                 bodyif.lineno           = generator.ifs[0].lineno
                 bodyif.col_offset       = generator.ifs[0].col_offset
-                if node_for_prev == None:
+                if node_for_prev is None:
                     #bodyif.body         = [array_load, node_call]
                     bodyif.body         = [node_call]
                 else:
                     bodyif.body         = [node_for_prev]
             else:
-                assert(bodyif == None)
+                assert(bodyif is None)
 
             node_for            = ast.For()
             node_for.target     = generator.target
@@ -1448,10 +1487,10 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
             node_for.orelse     = []
             node_for.lineno     = node.lineno
             node_for.col_offset = node.col_offset
-            if bodyif != None:
+            if bodyif is not None:
                 node_for.body   = [bodyif]
             else:
-                if node_for_prev == None:
+                if node_for_prev is None:
                     #node_for.body   = [array_load, node_call]
                     node_for.body   = [node_call]
                 else:
@@ -1561,7 +1600,7 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
                 bodyiftest.values       = []
                 for test in generator.ifs:
                     bodyiftest.values.append(test)
-                if node_for_prev == None:
+                if node_for_prev is None:
                     bodyif.body         = [add_Key_node]
                 else:
                     bodyif.body         = [node_for_prev]
@@ -1574,12 +1613,12 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
                 bodyif.orelse           = []
                 bodyif.lineno           = generator.ifs[0].lineno
                 bodyif.col_offset       = generator.ifs[0].col_offset
-                if node_for_prev == None:
+                if node_for_prev is None:
                     bodyif.body         = [add_Key_node]
                 else:
                     bodyif.body         = [node_for_prev]
             else:
-                assert(bodyif == None)
+                assert(bodyif is None)
 
             node_for            = ast.For()
             node_for.target     = generator.target
@@ -1587,10 +1626,10 @@ class Visitor_Of_FunCodeGen(ast.NodeVisitor):
             node_for.orelse     = []
             node_for.lineno     = node.lineno
             node_for.col_offset = node.col_offset
-            if bodyif != None:
+            if bodyif is not None:
                 node_for.body   = [bodyif]
             else:
-                if node_for_prev == None:
+                if node_for_prev is None:
                     node_for.body   = [add_Key_node]
                 else:
                     node_for.body   = [node_for_prev]
@@ -1640,7 +1679,7 @@ class FuncDescription:
         self.ref_type           = {}
 
         if is_global:
-            assert(global_map == None)
+            assert(global_map is None)
             self.name           = Global_simulation_func_name
             self.first_global_node = node
 
@@ -1653,7 +1692,7 @@ class FuncDescription:
             self.is_register_call   = False
             self.have_return_value  = False
             self.arg_num        = 0
-            assert(module_name != None)
+            assert(module_name is not None)
             #if self.isyscall:
             self.isyscall       = isyscall
             self.is_builtin     = is_builtin
@@ -1671,7 +1710,7 @@ class FuncDescription:
         visitor_stacksize.visit(self.func_ast)
         self.stack_size         += visitor_stacksize.stack_size
         #self.arg_num            = visitor_stacksize.arg_num
-        #print("Function %s. stack_size %d  self.arg_num %d" %(self.name, self.stack_size, self.arg_num))
+        #print("Function %s. stack_size %d  self.arg_num %d" % (self.name, self.stack_size, self.arg_num))
 
     def Check_VarRefLocal(self, name):
         if not (name in self.ref_type):
@@ -1691,7 +1730,7 @@ class FuncDescription:
         self.local_num += 1
 
         if (name in self.ref_type) and (self.ref_type[name] == ref_type_global):
-            if node != None:
+            if node is not None:
                 Print_Error_global(self.filepath, node, "Variable {} has ref as Global Variable. Check your code.".format(name))
             else:
                 raise Exception("Variable {} has ref as Global Variable. Check your code.".format(name))
@@ -1701,7 +1740,7 @@ class FuncDescription:
 
     def Get_LocalStackPosition(self, name, node = None):
         position = self.Read_LocalStackPosition(name, node)
-        if position != None:
+        if position is not None:
             return position
         else:
             return self.NewLocal(name, node)
@@ -1709,7 +1748,7 @@ class FuncDescription:
     def Read_LocalStackPosition(self, name, node = None):
         if name in self.local_map.keys():
             if (name in self.ref_type) and (self.ref_type[name] == ref_type_global):
-                if node != None:
+                if node is not None:
                     Print_Error_global(self.filepath, node, "Variable {} has ref as Global Variable. Check your code.".format(name))
                 else:
                     raise Exception("Variable {} has ref as Global Variable. Check your code.".format(name))
@@ -1721,12 +1760,12 @@ class FuncDescription:
 
     # code can both have global and local var with same name. but in function only can be local or global.
     def Read_Global_Position(self, name, node = None):
-        if self.global_map == None:
+        if self.global_map is None:
             return None
         else:
             if name in self.global_map.keys():
                 if (name in self.ref_type) and (self.ref_type[name] == ref_type_local):
-                    if node != None:
+                    if node is not None:
                         Print_Error_global(self.filepath, node, "Variable {} has ref as Local Variable. Check your code.".format(name))
                     else:
                         raise Exception("Variable {} has ref as Local Variable. Check your code.".format(name))
@@ -1887,7 +1926,7 @@ class CodeGenContext:
         self.write_file_with_str(json_data, savedfile)
 
     def Generate_Abi_list(self, main_func_node):
-        assert(self.file_hash != None)
+        assert(self.file_hash is not None)
         ABI_result = {}
         ABI_result["CompilerVersion"] = __version__
         ABI_result["hash"] = self.file_hash
@@ -1944,8 +1983,8 @@ class CodeGenContext:
 
     def Print_FuncScope(self):
         for i in self.funcscope.keys():
-            if self.funcscope[i].func_ast != None:
-                print("name: %s , label: %d, src_lineno: %d filepath: %s isyscall: %d argnum:%d" % (self.funcscope[i].name, self.funcscope[i].label, self.funcscope[i].src_lineno, self.funcscope[i].filepath, self.funcscope[i].isyscall, self.funcscope[i].arg_num))
+            if self.funcscope[i].func_ast is not None:
+                print("name: %s, label: %d, src_lineno: %d filepath: %s isyscall: %d argnum:%d" % (self.funcscope[i].name, self.funcscope[i].label, self.funcscope[i].src_lineno, self.funcscope[i].filepath, self.funcscope[i].isyscall, self.funcscope[i].arg_num))
             else:
                 assert(self.funcscope[i].is_register_call)
 
@@ -1957,7 +1996,7 @@ class CodeGenContext:
         fixed_line_visitor = generic_modify_node()
         fixed_line_visitor.visit(self.main_astree)
 
-        self.global_simulation_func = FuncDescription(name = Global_simulation_func_name, label = None , node = self.main_astree, isyscall = None, filepath = self.main_file_path, module_name = OwnMainModule, is_builtin = None,is_global = True)
+        self.global_simulation_func = FuncDescription(name = Global_simulation_func_name, label = None, node = self.main_astree, isyscall = None, filepath = self.main_file_path, module_name = OwnMainModule, is_builtin = None,is_global = True)
 
         self.global_simulation_func.Calculate_StackSize()
 
@@ -2022,7 +2061,7 @@ class CodeGenContext:
         #self.Print_FuncScope()
 
         # Convert Main.
-        if main_func_node == None:
+        if main_func_node is None:
             raise Exception("No Entry function defined. Please define a 'Main' function")
 
         self.current_func_node = main_func_node
@@ -2048,7 +2087,7 @@ class CodeGenContext:
 
     # Convert Func
     def ConvertFuncDecl(self, func_desc):
-        #assert(func_desc.func_ast != None)
+        #assert(func_desc.func_ast is not None)
         #ast.fix_missing_locations(func_desc.func_ast)
         #func_desc.Calculate_StackSize(self.global_num)
 
@@ -2094,10 +2133,10 @@ class CodeGenContext:
         funcast = node
         label   = self.NewLabel()
         #if not (isyscall or is_builtin):
-        #    newfunc = FuncDescription(name ,label, funcast, isyscall, filepath, module_name, is_builtin, False, self.global_simulation_func.local_map)
+        #    newfunc = FuncDescription(name,label, funcast, isyscall, filepath, module_name, is_builtin, False, self.global_simulation_func.local_map)
         #else:
-        #    newfunc = FuncDescription(name ,label, funcast, isyscall, filepath, module_name, is_builtin)
-        newfunc = FuncDescription(name ,label, funcast, isyscall, filepath, module_name, is_builtin)
+        #    newfunc = FuncDescription(name,label, funcast, isyscall, filepath, module_name, is_builtin)
+        newfunc = FuncDescription(name,label, funcast, isyscall, filepath, module_name, is_builtin)
 
         if name in self.funcscope.keys():
             oldfunc = self.funcscope[name]

--- a/ontology/code/StaticAppCall.py
+++ b/ontology/code/StaticAppCall.py
@@ -1,19 +1,22 @@
 import binascii
+
+
 class NotifyAction():
     def __init__(self, action_name, args):
-        self.action_name    = action_name
-        self.args           = args
+        self.action_name = action_name
+        self.args = args
         assert(type(args[0]).__name__ == 'Str')
-        self.event_name     = args[0].s
+        self.event_name = args[0].s
+
 
 class RegisterAppCall():
-    def __init__(self, func_name ,arguments):
-        self.func_name      = func_name
-        self.arguments      = arguments
+    def __init__(self, func_name, arguments):
+        self.func_name = func_name
+        self.arguments = arguments
         if type(arguments[0]).__name__ == 'Str':
-            self.script_hash    = arguments[0].s
+            self.script_hash = arguments[0].s
         elif type(arguments[0]).__name__ == 'Bytes':
-            self.script_hash    = arguments[0].s
+            self.script_hash = arguments[0].s
         else:
             print("RegisterAppCall only support Str or Bytes type addr")
             exit()

--- a/ontology/code/astvmtoken.py
+++ b/ontology/code/astvmtoken.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from ontology.interop import VMOp
 from ontology.interop.BigInteger import BigInteger
 
+
 class AstVMToken(object):
     @property
     def out_op(self):
@@ -10,17 +11,18 @@ class AstVMToken(object):
         elif type(self.vm_op) is bytes:
             return ord(self.vm_op)
         else:
-            raise Exception('[Error: filepath: %s. Line %d ] Invalid op: %s. used float? ' % (self.cur_func.filepath, self.node.lineno , str(self.vm_op)))
+            raise Exception('[Error: filepath: %s. Line %d ] Invalid op: %s. used float? ' % (self.cur_func.filepath, self.node.lineno, str(self.vm_op)))
 
     def __init__(self, vm_op, node, addr, cur_func, is_global, data=None):
-        self.vm_op              = vm_op
-        self.addr               = addr
-        self.data               = data
+        self.vm_op = vm_op
+        self.addr = addr
+        self.data = data
         # For Debugger
-        self.syscall_name       = None
-        self.node               = node
-        self.cur_func           = cur_func
-        self.is_global          = is_global
+        self.syscall_name = None
+        self.node = node
+        self.cur_func = cur_func
+        self.is_global = is_global
+
 
 class AstVMTokenizer(object):
     def __init__(self):
@@ -28,19 +30,19 @@ class AstVMTokenizer(object):
         self.vm_tokens = OrderedDict()
         # For Debugger
         self.current_func = None
-        self.global_converting  = False
+        self.global_converting = False
 
     def dump_all_vm_token(self):
         for addr in self.vm_tokens.keys():
             vm_token = self.vm_tokens[addr]
             vmop_name = VMOp.to_name(self.vm_tokens[addr].out_op)
-            if (type(vmop_name) == type(None)):
+            if vmop_name is None:
                 vmop_name = 'PUSHBYTES' + str(self.vm_tokens[addr].out_op)
 
-            #print("{:<10} {:<10}".format(addr, vmop_name))
+            # print("{:<10} {:<10}".format(addr, vmop_name))
             print("{:<10} {:<10} {:<10} {:<10}".format(vm_token.cur_func.name, vm_token.node.lineno, addr, vmop_name))
 
-    def build_function_stack(self, stack_size , node):
+    def build_function_stack(self, stack_size, node):
         self.Emit_Integer(stack_size, node)
         self.Emit_Token(VMOp.NEWARRAY, node)
         self.Emit_Token(VMOp.TOALTSTACK, node)
@@ -91,14 +93,14 @@ class AstVMTokenizer(object):
         return self.Emit_Token(code, node, byts)
 
     def Emit_PickGlobal(self, global_postion, node):
-        assert(global_postion != None and global_postion >= 0)
+        assert(global_postion is not None and global_postion >= 0)
         self.Emit_Token(VMOp.DUPFROMALTSTACK, node)
         self.Emit_Integer(global_postion, node)
         self.Emit_Token(VMOp.PICKITEM, node)
 
-    def Emit_LoadGlobal(self, position, global_postion ,node):
-        assert(position != None and position >= 0)
-        assert(global_postion != None and global_postion >= 0)
+    def Emit_LoadGlobal(self, position, global_postion, node):
+        assert(position is not None and position >= 0)
+        assert(global_postion is not None and global_postion >= 0)
         self.Emit_Token(VMOp.DUPFROMALTSTACK, node)
         self.Emit_Integer(global_postion, node)
         self.Emit_Token(VMOp.PICKITEM, node)
@@ -106,8 +108,8 @@ class AstVMTokenizer(object):
         self.Emit_Token(VMOp.PICKITEM, node)
 
     def Emit_StoreGlobal(self, position, global_postion, node):
-        assert(position != None and position >= 0)
-        assert(global_postion != None and global_postion >= 0)
+        assert(position is not None and position >= 0)
+        assert(global_postion is not None and global_postion >= 0)
         self.Emit_Token(VMOp.DUPFROMALTSTACK, node)
         self.Emit_Integer(global_postion, node)
         self.Emit_Token(VMOp.PICKITEM, node)
@@ -117,13 +119,13 @@ class AstVMTokenizer(object):
         self.Emit_Token(VMOp.SETITEM, node)
 
     def Emit_LoadLocal(self, position, node):
-        assert(position != None and position >= 0)
+        assert(position is not None and position >= 0)
         self.Emit_Token(VMOp.DUPFROMALTSTACK, node)
         self.Emit_Integer(position, node)
         self.Emit_Token(VMOp.PICKITEM, node)
 
     def Emit_StoreLocal(self, position, node):
-        assert(position != None and position >= 0)
+        assert(position is not None and position >= 0)
         self.Emit_Token(VMOp.DUPFROMALTSTACK, node)
         self.Emit_Integer(position, node)
         self.Emit_Integer(2, node)
@@ -204,8 +206,8 @@ class AstVMTokenizer(object):
         elif op == 'list':
             return self.Emit_Token(VMOp.NEWARRAY, node)
         elif op == 'print':
-            sys_name =  'System.Runtime.Log'
-            syscall_name =sys_name.encode('utf-8')
+            sys_name = 'System.Runtime.Log'
+            syscall_name = sys_name.encode('utf-8')
 
         if syscall_name:
             length = len(syscall_name)

--- a/ontology/code/astvmtoken.py
+++ b/ontology/code/astvmtoken.py
@@ -211,7 +211,7 @@ class AstVMTokenizer(object):
             length = len(syscall_name)
             ba = bytearray([length]) + bytearray(syscall_name)
             vmtoken = self.Emit_Token(VMOp.SYSCALL, node, data=ba)
-            vmtoken.syscall_name =sys_name 
+            vmtoken.syscall_name = sys_name
             return vmtoken
 
         return None


### PR DESCRIPTION
Fixed up the three files in the code folder so that they are in PEP8 style. This greatly improves the readability and caught a few minor issues (unused variables, checking the type of an object when it shouldn't). 

Also made fixes to some of the error messages where they were in broken/incorrect English.