### PR TITLE
Implemented has_key and wrote test

### DIFF
--- a/ontology/builtins.py
+++ b/ontology/builtins.py
@@ -160,3 +160,11 @@ def remove(arg):
 
 def reverse():
     pass
+
+
+def has_key(map, key):
+    """
+    :param map:
+    :param key:
+    """
+    pass

--- a/ontology/code/CodeGenerate_By_Ast.py
+++ b/ontology/code/CodeGenerate_By_Ast.py
@@ -29,8 +29,8 @@ Local_ArgLen = 'Local_ArgLen###FixedName'
 Function_Call_Arglen = 'Function_Call_Arglen###FixedName'
 Global_simulation_func_name = 'Global#Code'
 BUILTIN_AND_SYSCALL_LABEL_ADDR = -2
-# keys, values, has_key current not support
-# buildins_list           = ['state', 'bytes', 'bytearray', 'ToScriptHash', 'print', 'list', 'len', 'abs', 'min', 'max', 'concat', 'take', 'substr', 'keys', 'values', 'has_key', 'sha1', 'sha256', 'hash160', 'hash256', 'verify_signature', 'reverse', 'append', 'remove', 'Exception', 'throw_if_null', 'breakpoint']
+# The `keys` and `values` builtin functions are currently not supported
+# builtins_list = ['state', 'bytes', 'bytearray', 'ToScriptHash', 'print', 'list', 'len', 'abs', 'min', 'max', 'concat', 'take', 'substr', 'keys', 'values', 'has_key', 'sha1', 'sha256', 'hash160', 'hash256', 'verify_signature', 'reverse', 'append', 'remove', 'Exception', 'throw_if_null', 'breakpoint']
 ONE_LINE_EXPR_SUPPORT_AST_TYPE = ['Pass', 'Str']
 # xxx. Migrate have return value acctually.
 WITHOUT_RETURN_BUILTINSYSCALL = ['print', 'Log', 'throw_if_null', 'breakpoint', 'Notify', 'Put', 'Destroy', 'Delete', 'Exception']

--- a/testdata/test/test_dict_key.py
+++ b/testdata/test/test_dict_key.py
@@ -1,0 +1,16 @@
+OntCversion = '2.0.0'
+# !/usr/bin/env python3
+
+def Main(operation, args):
+    if operation == 'dictCheck':
+        key = args[0]
+        return dictCheck(key)
+    return False
+
+
+def dictCheck(key):
+    d = {
+      'a': 1,
+      'b': 2
+    }
+    return has_key(d, key)


### PR DESCRIPTION
`has_key` was added to the main Ontology project in https://github.com/ontio/ontology/commit/902dd123d18f82c588bc6c501b959655fa683441

Furthermore it is already supported in the compiler as an operation [here](https://github.com/ontio/ontology-python-compiler/blob/0c1dc0ac3693fae4c51ac3a9b2e68ccdfa3e8b53/ontology/code/astvmtoken.py).

I've added it to builtins and wrote a test demonstrating its use. I have confirmed that this works by compiling it, copying the byte code into smartx and running the tests manually. When passing in `'a'` it returns `Boolean(true)`, while passing in `'c'` returns `Boolean(false)`.