### PR TITLE
Fix tests from crashing when compiling

### DIFF
--- a/testdata/chain/AppCallTest.py
+++ b/testdata/chain/AppCallTest.py
@@ -1,7 +1,6 @@
 OntCversion = '2.0.0'
 from ontology.interop.System.App import RegisterAppCall, DynamicAppCall
 from ontology.libont import elt_in, hexstring2bytes, bytearray_reverse
-import boa.builtins
 
 # this address is add_test.py
 CalculatorContract = RegisterAppCall('1a6f62cc0ff3d9ae32b0b924aeda2056a9fdfccb', 'operation', 'args')

--- a/testdata/test/test_upper_lower.py
+++ b/testdata/test/test_upper_lower.py
@@ -1,3 +1,4 @@
+OntCversion = '2.0.0'
 from ontology.libont import upper, lower
 
 def Main():


### PR DESCRIPTION
- No need to import `builtins`
- All files need `OntCversion = '2.0.0'` at the top.
