### PR TITLE
Added contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+Contributing
+=========================================
+
+We welcome contributions. Please follow the guidelines when opening issues and contributing code to the repo.
+
+Contributing
+------------
+
+We follow the [fork-and-pull](https://stackoverflow.com/a/11582996/3830876) Git workflow:
+
+ 1. **Fork** the repo on GitHub
+ 2. **Clone** it to your own machine
+ 3. **Commit** changes to your fork
+ 4. **Push** changes to your fork
+ 5. Submit a **Pull request** for review
+
+**NOTE:** Be sure to merge the latest changes before making a pull request!
+
+Pull Requests
+------
+As outlined in Keavy McMinn's article ["How to write the perfect pull request"](https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/), you should include:
+
+  1. The purpose of the PR
+  2. A brief overview of what you did
+  3. Tag any issues that the PR relates to and [close issues with a keyword](https://help.github.com/en/articles/closing-issues-using-keywords)
+  4. What kind of feedback you're looking for (if any)
+  5. Tag individuals you want feedback from (if any)
+
+Issues
+------
+
+Feel free to submit issues and enhancement requests [here](https://github.com/ontio/ontology-python-compiler/issues/new). Please consider [how to ask a good question](https://stackoverflow.com/help/how-to-ask) and take the time to research your issue before asking for help.
+
+Duplicate questions will be closed.
+
+Any unrelated comments or questions can be asked in the [Ontology Discord](https://discordapp.com/invite/4TQujHj).

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ You can cleanup the compiled files with the `Makefile` using ```make clean```.
 
 ## Contributing
 
-We appreciate your help! New features, tests and documentation are all needed.
+Contributors are welcome to the `ontology-python-compiler`. Before beginning, please take a look at our [contributing guidelines](./CONTRIBUTING.md). You can open an issue by [clicking here](https://github.com/ontio/ontology-python-compiler/issues/new).
 
-Create a new pull request with your changes and be sure to include a description of what is being fixed.
+If you have any issues getting setup, open an issue or reach out in the [Ontology Discord](https://discordapp.com/invite/4TQujHj).
 
 ## License
 


### PR DESCRIPTION
I standardized the contributing guidelines with the Solo Chain project.

See https://github.com/punicasuite/solo-chain/pull/4 fo reference.