### PR TITLE
Compile directly to avm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 __pycache__
+*.pyc
+venv/

--- a/README.md
+++ b/README.md
@@ -80,21 +80,39 @@ pip install -r requirements.txt
 
 ## Usage
 
-The compiler may be used like in the following example:
-
+Import the compiler into a file with:
 ```
 from ontology.compiler import Compiler
+```
 
+The compiler can be used in three different ways:
+
+1) Compiling a python file to a new file
+```
 # Compiles the python file and creates an avm in 'path/to/your/file.avm'.
 compiler = Compiler.Compile('path/to/your/file.py')
+```
 
-# dump the instr instream.
+2) Compiling a python file to `.avm`
+```
+# Compiles the python file and returns an avm.
+avm = Compiler.Compile_File('path/to/your/file.py')
+```
+
+3) Compiling a variable to `.avm`
+```
+# Compiles a contract stored in memory and returns an avm.
+avm = Compiler.Compile_Contract('def Main(operation, args): ...')
+```
+
+You can also print out the instr instream:
+```
 compiler.DumpAsm()
 ```
 
 #### Testing
 
-You can run the tests using the ```runall.bash``` or ```runall-testing.bash``` files located in ```ontology_test```.
+You can run the tests using the ```runall.bash``` or ```runall-testing.bash``` files located in ```ontology_test```. You can run the compiler tests using the `compile-avm-test.py` file in the root directory.
 
 ## Contributing
 

--- a/basic-contract.py
+++ b/basic-contract.py
@@ -1,0 +1,11 @@
+OntCversion = '2.0.0'
+from ontology.interop.System.Runtime import Log
+
+def Main(operation, args):
+    if operation == 'LogTest':
+        return LogTest()
+    return False
+
+def LogTest():
+    Log('Hello, world!')
+    return True

--- a/compile-avm-test.py
+++ b/compile-avm-test.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+from ontology.compiler import Compiler
+
+def CompileContract():
+    sc = """OntCversion = '2.0.0'
+from ontology.interop.System.Runtime import Log
+
+def Main(operation, args):
+    if operation == 'LogTest':
+        return LogTest()
+    return False
+
+def LogTest():
+    Log('Hello, world!')
+    return True
+"""
+
+    try:
+        avm = Compiler.Compile_Contract(sc)
+        return avm
+    except Exception as error:
+        print("[CompileContract Error]: " + str(error))
+        return ""
+
+def CompileFile():
+    try:
+        avm = Compiler.Compile_File("basic-contract.py")
+        return avm
+    except Exception as error:
+        print("[CompileFile Error]: " + str(error))
+        return ""
+
+assert CompileContract() == CompileFile(), 'Compile test failed'

--- a/ontology/compiler.py
+++ b/ontology/compiler.py
@@ -44,6 +44,62 @@ class Compiler(object):
 
         return compiler
 
+    @staticmethod
+    def Compile_File(path):
+        """
+        :param path: the path of the Python file to compile
+        :return: avm
+
+        The following returns the avm string for the contract.
+
+        .. code-block:: python
+
+            from ontology.compiler import Compiler
+
+            avm = Compiler.Compile_File('path/to/your/file.py')
+        """
+
+        Compiler.Compile(path)
+        words = path.split(".")
+        base = words[0] if len(words) == 2 else path
+        avm_file = base + ".avm.str"
+
+        if os.path.isfile(path):
+            os.remove(base + ".abi.json")
+            os.remove(base + ".avm")
+            os.remove(base + ".debug.json")
+            os.remove(base + ".Func.Map")
+            os.remove(base + ".warning")
+
+        with open(avm_file) as f:
+            content = f.read()
+            os.remove(avm_file)
+            return content
+
+    @staticmethod
+    def Compile_Contract(contract):
+        """
+        :param contract: a string containing an entire contract
+        :return: avm
+
+        The following returns the avm string for the contract.
+
+        .. code-block:: python
+
+            from ontology.compiler import Compiler
+
+            avm = Compiler.Compile_Contract('def Main(): ...')
+        """
+
+        path = "tmp_contract.py"
+        temp = open(path, "w")
+        temp.write(contract)
+        temp.close()
+        avm = Compiler.Compile_File(path)
+        if os.path.isfile(path):
+            os.remove(path)
+        return avm
+
     def DumpAsm(self):
         self.CodeGenerate.Dump_Asm()
 


### PR DESCRIPTION
The compiler can now be passed a file or a properly formatted smart contract string and return an avm string directly.